### PR TITLE
Setting up Grafana Dashboards: change log level formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@ Located in the `/docs` directory. `*.json` file is used for rendering, `*.yaml` 
 
 Also published on GitHub pages: https://catbytes-community.github.io/webplatform-backend/
 
+### Monitoring
+Service logs are sent to Grafana. Main dashboard: https://catbytes.grafana.net/goto/S3QCkuxHR?orgId=1
+Here are also some predefined queries to search in logs:
+
+| Environment    | Url |
+| -------- | ------- |
+| DEV  | https://catbytes.grafana.net/goto/dkl-MubNg?orgId=1   |
+| PROD | https://catbytes.grafana.net/goto/cvZfGXbNR?orgId=1     |
+
+Insert value you're looking for in the 'Line contains' box.
+
 ### Documentation for developers
 
 Located in the `/docs/how-tos` directory. All important information on local run, deployments, etc is stored there.

--- a/logger.js
+++ b/logger.js
@@ -22,7 +22,12 @@ const baseLogger = pino({
         messageFormat: '[{module}] {msg}'
       }
     }
-    : undefined // raw json for prod/Loki
+    : undefined, // raw json for prod/Loki
+  formatters: {
+    level: (label) => {
+      return { level: label.toLowerCase() };
+    },
+  }
 });
 
 function getLogger(callerFilename) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2552,6 +2552,15 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/axios": {
       "version": "1.8.4",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
@@ -2576,15 +2585,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/atomic-sleep": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
-      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/balanced-match": {


### PR DESCRIPTION
This is a tiny change needed for Grafana to correctly pick up log level.
Before: log level is numeric, log line color is grey - level undetected. After: log level is string, color is matching log severity.
<img width="1057" alt="Screenshot 2025-05-08 at 18 35 44" src="https://github.com/user-attachments/assets/fdafb554-7d77-475a-ac2b-b9f859ddf4a9" />

Also added information about logs and some Grafana links to readme.
To search for something in logs, you can use quick link from the readme for the relevant environment. Insert value you're looking for into the 'Line contains' box:
<img width="1512" alt="Screenshot 2025-05-08 at 18 42 49" src="https://github.com/user-attachments/assets/93a8554b-05d2-4c22-87f7-78fe83e36288" />

