### PR TITLE
updates platform_url to redirect to new frontend url on dev

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -10,5 +10,5 @@
   "cors": {
     "allowedOrigins": ["http://localhost:5173", "https://dev.catbytes.io", "https://app.dev.catbytes.io"]
   },
-  "platform_url": "https://dev.catbytes.io/"
+  "platform_url": "https://app.dev.catbytes.io/"
 }


### PR DESCRIPTION
This PR just updates development platform_url, as frontend url changed to `app.dev.catbytes.io`.
platform_url is also used in the email as a redirect link on login